### PR TITLE
Don't check isLiveVersion on owned objects that don't support it

### DIFF
--- a/code/TemplateAugmentor.php
+++ b/code/TemplateAugmentor.php
@@ -77,7 +77,7 @@ class TemplateAugmentor extends DataExtension
                 $owned = $this->owner->findOwned();
 
                 foreach ($owned as $item) {
-                    if (!$item->isLiveVersion()) {
+                    if ($item->hasMethod('isLiveVersion') && !$item->isLiveVersion()) {
                         $ownedNotLive = $item;
                         break;
                     }


### PR DESCRIPTION
For some reason File Link shortcodes show up as owned items but don't have an `isLiveVersion` method. Luckly, their target files also show up as owned items, so we can just ignore the File Link.